### PR TITLE
Add mixed precision support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ siamese_nets_classifier
 .coverage
 *egg-info
 logs
+.python-version

--- a/keras_fsl/losses/gram_matrix_losses.py
+++ b/keras_fsl/losses/gram_matrix_losses.py
@@ -12,8 +12,8 @@ representation, see for instance
 """
 import tensorflow as tf
 import tensorflow.keras.backend as K
-from tensorflow.keras.losses import Loss
 import tensorflow_probability as tfp
+from tensorflow.keras.losses import Loss
 
 
 class MeanScoreClassificationLoss(Loss):
@@ -70,8 +70,11 @@ class ClippedBinaryCrossentropy(BinaryCrossentropy):
 
     def call(self, y_true, y_pred):
         loss = super().call(y_true, y_pred)
-        clip_mask = tf.math.logical_and(-tf.math.log(1 - self.lower) < loss, loss < -tf.math.log(1 - self.upper))
-        return tf.cast(clip_mask, dtype=y_pred.dtype) * loss
+        clip_mask = tf.math.logical_and(
+            -tf.math.log(1 - tf.cast(self.lower, dtype=loss.dtype)) < loss,
+            loss < -tf.math.log(1 - tf.cast(self.upper, dtype=loss.dtype)),
+        )
+        return tf.cast(clip_mask, dtype=loss.dtype) * loss
 
 
 # TODO: use reduction kwarg of loss when it becomes possible to give custom reduction to includes all other reductions below in

--- a/keras_fsl/losses/tests/gram_matrix_losses_test.py
+++ b/keras_fsl/losses/tests/gram_matrix_losses_test.py
@@ -140,6 +140,11 @@ class TestGramMatrixLoss:
             )
             np.testing.assert_almost_equal(tf_loss, np_loss, decimal=5)
 
+        def test_clipped_loss_computes_in_float16(self, y_true, y_pred):
+            ClippedBinaryCrossentropy(lower=0.05, upper=0.95)(
+                tf.convert_to_tensor(y_true, tf.float16), tf.convert_to_tensor(y_pred, tf.float16)
+            )
+
         def test_max_loss_should_equal_literal_calculation(self, y_true, adjacency_matrix, y_pred):
             np_loss = np.max(-(adjacency_matrix * np.log(y_pred) + (1 - adjacency_matrix) * np.log(1 - y_pred)))
             tf_loss = MaxBinaryCrossentropy()(

--- a/keras_fsl/losses/tests/gram_matrix_losses_test.py
+++ b/keras_fsl/losses/tests/gram_matrix_losses_test.py
@@ -140,9 +140,13 @@ class TestGramMatrixLoss:
             )
             np.testing.assert_almost_equal(tf_loss, np_loss, decimal=5)
 
-        def test_clipped_loss_computes_in_float16(self, y_true, y_pred):
+        @staticmethod
+        @pytest.mark.parametrize("dtype_policy", (tf.float16, tf.bfloat16, tf.float32, tf.float64))
+        def test_clipped_loss_computes_in_all_float_dtypes(dtype_policy, y_true, y_pred):
+            y_true_tensor = tf.convert_to_tensor(y_true)
+            y_pred_tensor = tf.convert_to_tensor(y_pred)
             ClippedBinaryCrossentropy(lower=0.05, upper=0.95)(
-                tf.convert_to_tensor(y_true, tf.float16), tf.convert_to_tensor(y_pred, tf.float16)
+                tf.cast(y_true_tensor, dtype=dtype_policy), tf.cast(y_pred_tensor, dtype=dtype_policy)
             )
 
         def test_max_loss_should_equal_literal_calculation(self, y_true, adjacency_matrix, y_pred):


### PR DESCRIPTION
# Context

Some Sicara project using Keras FSL was needing support for mixed precision, which was not possible for some classes until now.

# Changes

- Updated `ClippedBinaryCrossentropy` loss to cast float parameters to loss dtype when computations are done in type other than float32
- Update LearntNorms to use float32 precision in last activation layer when using mixed precision

# To Do after this

- Update all repository for mixed precision support